### PR TITLE
Incorrect esES number separators.

### DIFF
--- a/Locales/NumberFormats.lua
+++ b/Locales/NumberFormats.lua
@@ -105,8 +105,8 @@ local localeNumberFormats = {
 	 
 	-- esES: Spanish (Spain)
 	["esES"] = {	
-		["thousandsSeparator"] = ",",
-		["decimalSeparator"] = ".",
+		["thousandsSeparator"] = ".",
+		["decimalSeparator"] = ",",
 		["leadingSpace"] = " ",
 		["trailingSpace"] = " ",
 		["unitsTable"] = {


### PR DESCRIPTION
Changed esES thousands and decimal separators ("." and ",").

They were inverted and the addon was reading "1,5" as "15" millions.